### PR TITLE
fix(e2e): prevent flaky tests by using fixed item names

### DIFF
--- a/src/infra/http/controllers/item/fetch-items.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/item/fetch-items.controller.e2e-spec.ts
@@ -24,9 +24,9 @@ describe('[GET] /items', () => {
 
   test('should fetch all active items ordered by name asc by default', async () => {
     const newCategory = await categoryFactory.makePrismaCategory({})
-    await itemFactory.makePrismaItem({ code: '3', price: 25.99, categoryId: newCategory.id })
-    await itemFactory.makePrismaItem({ code: '2', price: 20, categoryId: newCategory.id })
-    await itemFactory.makePrismaItem({ code: '1', price: 20, categoryId: newCategory.id, active: false })
+    await itemFactory.makePrismaItem({ name: 'Item 3', code: '3', price: 25.99, categoryId: newCategory.id })
+    await itemFactory.makePrismaItem({ name: 'Item 2', code: '2', price: 20, categoryId: newCategory.id })
+    await itemFactory.makePrismaItem({ name: 'Item 1', code: '1', price: 20, categoryId: newCategory.id, active: false })
     const response = await request(app.getHttpServer()).get('/items').send()
     expect(response.statusCode).toBe(200)
     expect(response.body).toEqual({

--- a/src/infra/http/controllers/item/update-item.controller.e2e-spec.ts
+++ b/src/infra/http/controllers/item/update-item.controller.e2e-spec.ts
@@ -26,8 +26,8 @@ describe('[PATCH] /items/:itemId', () => {
   })
 
   test('should update item details successfully', async () => {
-    const category1 = await categoryFactory.makePrismaCategory({})
-    const category2 = await categoryFactory.makePrismaCategory({})
+    const category1 = await categoryFactory.makePrismaCategory({ name: 'Category 1' })
+    const category2 = await categoryFactory.makePrismaCategory({ name: 'Category 2' })
     const item = await itemFactory.makePrismaItem({
       code: 'ITM-02',
       name: 'Old Name',


### PR DESCRIPTION
### 📝 Description

- Fixes inconsistent failures in the `fetch-items` and `update-item` e2e tests caused by random item name and category name generation.
- Uses fixed item names to ensure predictable sorting and stable test results.

---

### ✅ Test Results

#### - End-to-End
<img width="704" height="90" alt="image" src="https://github.com/user-attachments/assets/b7b2723b-c534-488e-b187-ad87049a27a5" />