### PR TITLE
Feat: Auto-restore deleted/inactive categories on create with an existing name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@opentelemetry/sdk-node": "^0.203.0",
         "@prisma/client": "^6.8.2",
         "@prisma/instrumentation": "^6.13.0",
-        "@scalar/nestjs-api-reference": "^0.5.12",
+        "@scalar/nestjs-api-reference": "^0.5.14",
         "@willsoto/nestjs-prometheus": "^6.0.2",
         "mercadopago": "^2.8.0",
         "nestjs-pino": "^4.4.0",
@@ -4182,12 +4182,12 @@
       ]
     },
     "node_modules/@scalar/nestjs-api-reference": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@scalar/nestjs-api-reference/-/nestjs-api-reference-0.5.12.tgz",
-      "integrity": "sha512-hv8ycGXAPmzu66m7ttzgbG9jJyM3a4dYsCsC6gVVUJ1FyjWzMcy8MJeuQ13LXi1cnR6v/KAPtOfmFGBLx4+3lQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/@scalar/nestjs-api-reference/-/nestjs-api-reference-0.5.14.tgz",
+      "integrity": "sha512-SYWChX6ntmhRorDjN4mwQ72ZKazET7OiIKp5LnbUUZiN3GzVzhiFl5PHZthSH2W6UWjds3JQlW0Xgt7vyQzf9w==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.2.11"
+        "@scalar/types": "0.2.13"
       },
       "engines": {
         "node": ">=20"
@@ -4215,9 +4215,9 @@
       }
     },
     "node_modules/@scalar/types": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.2.11.tgz",
-      "integrity": "sha512-SUZzGmoisWsYv33LmmT/ajvSlcl9ZDj9d5RncJ+wB9ZQ2l018xlfpDIH9Kdfo+6KCKQOe3LYLXfH4Lzm891Mag==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.2.13.tgz",
+      "integrity": "sha512-rO6KGMJqOsBnN/2R4fErMFLpRSPVJElni+HABDpf+ZlLJp2lvxuPn0IXLumK5ytfplUH9iqKgSXjndnZfxSYLQ==",
       "license": "MIT",
       "dependencies": {
         "@scalar/openapi-types": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/sdk-node": "^0.203.0",
     "@prisma/client": "^6.8.2",
     "@prisma/instrumentation": "^6.13.0",
-    "@scalar/nestjs-api-reference": "^0.5.12",
+    "@scalar/nestjs-api-reference": "^0.5.14",
     "@willsoto/nestjs-prometheus": "^6.0.2",
     "mercadopago": "^2.8.0",
     "nestjs-pino": "^4.4.0",

--- a/src/application/category/repositories/category-repository.ts
+++ b/src/application/category/repositories/category-repository.ts
@@ -4,6 +4,7 @@ import { FetchCategoriesSearchParams } from '../@types/fetch-categories-search-f
 export abstract class CategoryRepository {
   abstract existsByName(name: string): Promise<boolean>
   abstract findById(id: string): Promise<Category | null>
+  abstract findByName(id: string): Promise<Category | null>
   abstract findMany(params: FetchCategoriesSearchParams): Promise<Category[]>
   abstract save(category: Category): Promise<void>
   abstract update(category: Category): Promise<void>

--- a/src/application/category/use-cases/create-category.spec.ts
+++ b/src/application/category/use-cases/create-category.spec.ts
@@ -29,7 +29,7 @@ describe('Create Category Use Case', () => {
     await expect(sut.execute(input)).rejects.toThrowError('Category already exists')
   })
 
-  it('should restore a existing category if deleted', async () => {
+  it('should restore existing deleted category when creating with same name', async () => {
     const deletedCategory = Category.create({
       name: 'Category Name',
       deletedAt: new Date(),

--- a/src/application/category/use-cases/create-category.spec.ts
+++ b/src/application/category/use-cases/create-category.spec.ts
@@ -15,7 +15,7 @@ describe('Create Category Use Case', () => {
     const input = {
       name: 'Category Name',
     }
-    const result = await sut.execute(input)
+    await sut.execute(input)
     expect(categoryRepository.categories).toHaveLength(1)
     expect(categoryRepository.categories[0].name).toBe('Category Name')
   })
@@ -27,5 +27,16 @@ describe('Create Category Use Case', () => {
     const newCategory = Category.create(input)
     await categoryRepository.save(newCategory)
     await expect(sut.execute(input)).rejects.toThrowError('Category already exists')
+  })
+
+  it('should restore a existing category if deleted', async () => {
+    const deletedCategory = Category.create({
+      name: 'Category Name',
+      deletedAt: new Date(),
+    })
+    await categoryRepository.save(deletedCategory)
+    const input = { name: 'Category Name' }
+    await sut.execute(input)
+    expect(categoryRepository.categories[0].deletedAt).toBeNull()
   })
 })

--- a/src/application/category/use-cases/create-category.ts
+++ b/src/application/category/use-cases/create-category.ts
@@ -13,9 +13,14 @@ export class CreateCategoryUseCase {
 
   @Span()
   async execute(input: CreateCategoryInput): Promise<void> {
-    const existingCategory = await this.categoryRepository.existsByName(input.name)
-    if (existingCategory) throw new Error('Category already exists')
-    const category = Category.create(input)
-    await this.categoryRepository.save(category)
+    const existingCategory = await this.categoryRepository.findByName(input.name)
+    if (existingCategory) {
+      if (existingCategory.isActive()) throw new Error('Category already exists')
+      existingCategory.restore()
+      await this.categoryRepository.update(existingCategory)
+      return
+    }
+    const newCategory = Category.create(input)
+    await this.categoryRepository.save(newCategory)
   }
 }

--- a/src/infra/database/prisma/repositories/prisma-category-repository.ts
+++ b/src/infra/database/prisma/repositories/prisma-category-repository.ts
@@ -26,6 +26,14 @@ export class PrismaCategoryRepository implements CategoryRepository {
     return PrismaCategoryMapper.toDomain(category)
   }
 
+  async findByName(name: string): Promise<Category | null> {
+    const category = await this.prisma.category.findUnique({
+      where: { name },
+    })
+    if (!category) return null
+    return PrismaCategoryMapper.toDomain(category)
+  }
+
   async findMany(params: FetchCategoriesSearchParams): Promise<Category[]> {
     const status = params.status ?? CategoryStatus.ACTIVE
     const sortOrder = params.sortOrder ?? 'asc'

--- a/test/repositories/in-memory-category-repository.ts
+++ b/test/repositories/in-memory-category-repository.ts
@@ -13,6 +13,10 @@ export class InMemoryCategoryRepository implements CategoryRepository {
     return this.categories.find(category => category.id === id) || null
   }
 
+  async findByName(name: string): Promise<Category | null> {
+    return this.categories.find(category => category.name === name) || null
+  }
+
   async findMany(params: FetchCategoriesSearchParams): Promise<Category[]> {
     const status = params.status ?? CategoryStatus.ACTIVE
     const sortOrder = params.sortOrder ?? 'asc'


### PR DESCRIPTION
## Changes

- Modified `CreateCategoryUseCase` to check for existing categories by name (active, inactive, or deleted)
- Categories with matching names are automatically restored instead of creating duplicates
- Replaced `existsByName()` with `findByName()` to get complete category state
- Added proper error handling for edge cases
- Other: update `Scalar` lib version

## Behavior

**Before**: 
1. Creating a category with an existing name would fail with "Category already exists"

**After**:
1. Active categories with same name → throw conflict error
3. Inactive/deleted categories with same name → automatically restore and return
4. Non-existent categories → create new category

---

### ✅ Test Results

#### - Unit & Integration
<img width="851" height="123" alt="image" src="https://github.com/user-attachments/assets/8dfeab81-42f2-4f8d-8653-3fd3ced17cb8" />

#### - End-to-End
<img width="753" height="86" alt="image" src="https://github.com/user-attachments/assets/75a8065d-5f5c-49b6-ab66-ddb2595c029f" />
